### PR TITLE
Fix #76 - uninitialized overallStatus

### DIFF
--- a/library/Vspheredb/Sync/SyncManagedObjectReferences.php
+++ b/library/Vspheredb/Sync/SyncManagedObjectReferences.php
@@ -48,6 +48,7 @@ class SyncManagedObjectReferences
             $uuid = $vCenter->makeBinaryGlobalUuid($moRef);
             $fetched[$uuid] = $name;
             $nameUuids[$moRef] = $uuid;
+            $obj->overallStatus = isset($obj->overallStatus) ? $obj->overallStatus : 'gray';  //** Handle cases where Vcenter gives us a blank overallStatus.**/
             if (array_key_exists($uuid, $objects)) {
                 $object = $objects[$uuid];
                 $object->set('moref', $moRef);


### PR DESCRIPTION
Initialize overallStatus if empty, before attempting to create or update moRefs entries in the DB