### PR TITLE
Update mysql.sql

### DIFF
--- a/schema/mysql.sql
+++ b/schema/mysql.sql
@@ -827,7 +827,7 @@ CREATE TABLE performance_counter (
   label VARCHAR(96) NOT NULL,
   group_name VARCHAR(32) NOT NULL,
   unit_name VARCHAR(32) NOT NULL,
-  summary VARCHAR(255) NOT NULL,
+  summary text NOT NULL,
   stats_type ENUM( -- statsType
     'absolute',
     'delta',


### PR DESCRIPTION
Update Table to fix ERROR

ERROR:
Task perfCounterInfo failed: SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'summary' at row 1, query was: INSERT INTO performance_counter (vcenter_uuid, counter_key, name, group_name, unit_name, label, summary, rollup_type, stats_type, level, per_device_level) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'summary' at row 1, query was: INSERT INTO performance_counter (vcenter_uuid, counter_key, name, group_name, unit_name, label, summary, rollup_type, stats_type, level, per_device_level) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)