### PR TITLE
Update upgrade_12.sql

### DIFF
--- a/schema/mysql-migrations/upgrade_12.sql
+++ b/schema/mysql-migrations/upgrade_12.sql
@@ -31,7 +31,7 @@ CREATE TABLE performance_counter (
   vcenter_uuid VARBINARY(16) NOT NULL,
   counter_key INT UNSIGNED NOT NULL,
   name VARCHAR(32) NOT NULL COLLATE utf8_bin,
-  label VARCHAR(96) NOT NULL,
+  label VARCHAR(255) NOT NULL,
   group_name VARCHAR(32) NOT NULL,
   unit_name VARCHAR(32) NOT NULL,
   summary VARCHAR(255) NOT NULL,


### PR DESCRIPTION
Update Table to fix ERROR


ERROR:
Task perfCounterInfo failed: SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'label' at row 1, query was: INSERT INTO performance_counter (vcenter_uuid, counter_key, name, group_name, unit_name, label, summary, rollup_type, stats_type, level, per_device_level) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'label' at row 1, query was: INSERT INTO performance_counter (vcenter_uuid, counter_key, name, group_name, unit_name, label, summary, rollup_type, stats_type, level, per_device_level) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)