### PR TITLE
Patch 3

### DIFF
--- a/schema/mysql.sql
+++ b/schema/mysql.sql
@@ -824,7 +824,7 @@ CREATE TABLE performance_counter (
   vcenter_uuid VARBINARY(16) NOT NULL,
   counter_key INT UNSIGNED NOT NULL,
   name VARCHAR(32) NOT NULL COLLATE utf8_bin,
-  label VARCHAR(96) NOT NULL,
+  label VARCHAR(255) NOT NULL,
   group_name VARCHAR(32) NOT NULL,
   unit_name VARCHAR(32) NOT NULL,
   summary VARCHAR(255) NOT NULL,

--- a/schema/mysql.sql
+++ b/schema/mysql.sql
@@ -827,7 +827,7 @@ CREATE TABLE performance_counter (
   label VARCHAR(255) NOT NULL,
   group_name VARCHAR(32) NOT NULL,
   unit_name VARCHAR(32) NOT NULL,
-  summary VARCHAR(255) NOT NULL,
+  summary text NOT NULL,
   stats_type ENUM( -- statsType
     'absolute',
     'delta',


### PR DESCRIPTION
Update Table "performance_counter" to fix ERROR

label VARCHAR(96) -> label VARCHAR(255)
summary VARCHAR(255) -> summary text

LABEL-ERROR:
Task perfCounterInfo failed: SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'label' at row 1, query was: INSERT INTO performance_counter (vcenter_uuid, counter_key, name, group_name, unit_name, label, summary, rollup_type, stats_type, level, per_device_level) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'label' at row 1, query was: INSERT INTO performance_counter (vcenter_uuid, counter_key, name, group_name, unit_name, label, summary, rollup_type, stats_type, level, per_device_level) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)

SUMMARY-ERROR:
Task perfCounterInfo failed: SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'summary' at row 1, query was: INSERT INTO performance_counter (vcenter_uuid, counter_key, name, group_name, unit_name, label, summary, rollup_type, stats_type, level, per_device_level) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'summary' at row 1, query was: INSERT INTO performance_counter (vcenter_uuid, counter_key, name, group_name, unit_name, label, summary, rollup_type, stats_type, level, per_device_level) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)