### PR TITLE
Remove trailing comma in function call to restore < PHP 7.3 compatibility

### DIFF
--- a/library/Vspheredb/Daemon/DbCleanup.php
+++ b/library/Vspheredb/Daemon/DbCleanup.php
@@ -41,7 +41,7 @@ WHERE;
         $result = $db->delete('vspheredb_daemon', $where);
         if ($result > 0) {
             $this->logger->info(
-                "Removed information related to $result formerly running daemon instance(s)",
+                "Removed information related to $result formerly running daemon instance(s)"
             );
         }
         $db->query('OPTIMIZE TABLE vspheredb_daemon')->execute();


### PR DESCRIPTION
When running PHP 7.0.33 (which should be supported by this module) and upgrading this module to 1.2.0 the database daemon doesn't start properly anymore:

```shell
icinga@icinga:~# icingacli vspheredb daemon run
notice: [configwatch] DB configuration loaded
notice: [db] sending DB config to child process
error: DB runner is failing: Got invalid NetString data:
Parse error: syntax error, unexpected ')' in /usr/share/icingaweb2/modules/vspheredb/library/Vspheredb/Daemon/DbCleanup.php on line 45

error: [configwatch] Sending DB Config failed: Connection closed
error: Process exited with exit code 255
error: DB runner is failing: Process exited with exit code 255
```

The line before line number 45 contains a single trailing comma which was introduced in PHP 7.3: https://wiki.php.net/rfc/trailing-comma-function-calls

To restore compatibility with PHP 5.6 - 7.2, I removed that trailing comma with this PR.