### PR TITLE
Add notice for SELinux enabled systems

### DIFF
--- a/doc/01-Installation.md
+++ b/doc/01-Installation.md
@@ -44,6 +44,15 @@ Please make sure that you choose `utf8mb4` as an encoding.
 Installation
 ------------
 
+### SELinux notice
+
+When installing the module on a system with SELinux enabled,
+execute the following command to assign the appropriate context to the module's daemon socket directory:
+
+```shell
+semanage fcontext -a -t icingaweb2_rw_content_t '/run/icinga-vspheredb(/.*)?'
+```
+
 ### Module installation (or upgrade)
 
 This script downloads the [latest version](https://github.com/Icinga/icingaweb2-module-vspheredb/releases)


### PR DESCRIPTION
After the update to v1.2.0 on a system where SELinux is running you get the following error message in the web interface
![image](https://user-images.githubusercontent.com/24474580/144617954-38070181-9826-4b9f-9e15-8344484f8e9c.png)

To work around this problem you can set the SELinux context for the /var/run/icinga-vspheredb folder with the following command
`semanage fcontext -a -t icingaweb2_rw_content_t '/var/run/icinga-vspheredb(/.*)?'`

This command has to be run prior to the whole installation process of the module, the users and the other stuff.