### PR TITLE
Fix typos for then/than wording

### DIFF
--- a/application/locale/de_DE/LC_MESSAGES/vspheredb.po
+++ b/application/locale/de_DE/LC_MESSAGES/vspheredb.po
@@ -1674,12 +1674,12 @@ msgid "Raise Critical if more than X snapshots"
 msgstr "Kritisch melden für mehr als X Schnappschüsse"
 
 #: library/Vspheredb/Monitoring/Rule/Definition/MemoryUsageHelper.php:102
-msgid "Raise Critical with less then X MBytes free"
+msgid "Raise Critical with less than X MBytes free"
 msgstr "Kritisch melden mit weniger als X MBytes frei"
 
 #: library/Vspheredb/Monitoring/Rule/Definition/CpuUsageRuleDefinition.php:108
 #: library/Vspheredb/Monitoring/Rule/Definition/MemoryUsageHelper.php:94
-msgid "Raise Critical with less then X percent free"
+msgid "Raise Critical with less than X percent free"
 msgstr "Kritisch melden mit weniger als X Prozent frei"
 
 #: library/Vspheredb/Monitoring/Rule/Definition/PowerStateRuleDefinition.php:180
@@ -1703,12 +1703,12 @@ msgid "Raise Warning if more than X snapshots"
 msgstr "Warnung melden für mehr als X Schnappschüsse"
 
 #: library/Vspheredb/Monitoring/Rule/Definition/MemoryUsageHelper.php:98
-msgid "Raise Warning with less then X MBytes free"
+msgid "Raise Warning with less than X MBytes free"
 msgstr "Warnung melden mit weniger als X MBytes frei"
 
 #: library/Vspheredb/Monitoring/Rule/Definition/CpuUsageRuleDefinition.php:104
 #: library/Vspheredb/Monitoring/Rule/Definition/MemoryUsageHelper.php:90
-msgid "Raise Warning with less then X percent free"
+msgid "Raise Warning with less than X percent free"
 msgstr "Warnung melden mit weniger als X Prozent frei"
 
 #: library/Vspheredb/Web/Form/DeleteVCenterForm.php:53

--- a/library/Vspheredb/Monitoring/Rule/Definition/CpuUsageRuleDefinition.php
+++ b/library/Vspheredb/Monitoring/Rule/Definition/CpuUsageRuleDefinition.php
@@ -101,11 +101,11 @@ class CpuUsageRuleDefinition extends MonitoringRuleDefinition
     {
         return [
             'warning_if_less_than_percent_free' => ['number', [
-                'label' => $this->translate('Raise Warning with less then X percent free'),
+                'label' => $this->translate('Raise Warning with less than X percent free'),
                 'placeholder' => '30',
             ]],
             'critical_if_less_than_percent_free' => ['number', [
-                'label' => $this->translate('Raise Critical with less then X percent free'),
+                'label' => $this->translate('Raise Critical with less than X percent free'),
                 'placeholder' => '10',
             ]],
         ];

--- a/library/Vspheredb/Monitoring/Rule/Definition/MemoryUsageHelper.php
+++ b/library/Vspheredb/Monitoring/Rule/Definition/MemoryUsageHelper.php
@@ -87,19 +87,19 @@ class MemoryUsageHelper
                 ],
             ]],
             'warning_if_less_than_percent_free' => ['number', [
-                'label' => $t->translate('Raise Warning with less then X percent free'),
+                'label' => $t->translate('Raise Warning with less than X percent free'),
                 'placeholder' => '5',
             ]],
             'critical_if_less_than_percent_free' => ['number', [
-                'label' => $t->translate('Raise Critical with less then X percent free'),
+                'label' => $t->translate('Raise Critical with less than X percent free'),
                 'placeholder' => '2',
             ]],
             'warning_if_less_than_mbytes_free' => ['number', [
-                'label' => $t->translate('Raise Warning with less then X MBytes free'),
+                'label' => $t->translate('Raise Warning with less than X MBytes free'),
                 'placeholder' => '500',
             ]],
             'critical_if_less_than_mbytes_free' => ['number', [
-                'label' => $t->translate('Raise Critical with less then X MBytes free'),
+                'label' => $t->translate('Raise Critical with less than X MBytes free'),
                 'placeholder' => '100',
             ]],
         ];


### PR DESCRIPTION
I assume that `./application/locale/de_DE/LC_MESSAGES/vspheredb.mo` needs to be recreated, but I'm not sure how to properly do that.