### PR TITLE
Add 'standBy' power state

### DIFF
--- a/library/Vspheredb/Monitoring/Rule/Definition/PowerStateRuleDefinition.php
+++ b/library/Vspheredb/Monitoring/Rule/Definition/PowerStateRuleDefinition.php
@@ -140,6 +140,8 @@ class PowerStateRuleDefinition extends MonitoringRuleDefinition
                 return "$what power state is unknown, might be disconnected";
             case 'poweredOn':
                 return "$what is powered on";
+            case 'standBy':
+                return "$what is in standby";
         }
 
         throw new InvalidArgumentException("'$state' is not a known power state");


### PR DESCRIPTION
Adds 'standBy' as a known power state for hosts that are [powered down, but in standby (DRS/DPM feature of VMware)](https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-resource-management/GUID-B9CDDD4F-A8CE-4700-8CF6-E7D0F1E0478E.html).