### PR TITLE
Revert parts of commit e14d363

### DIFF
--- a/library/Vspheredb/Daemon/DbLogger.php
+++ b/library/Vspheredb/Daemon/DbLogger.php
@@ -31,8 +31,6 @@ class DbLogger implements LogWriterWithContext, EventEmitterInterface
 
     protected $pid;
 
-    protected $lastTs = null;
-
     public function __construct($instanceUuid, $fqdn, $pid)
     {
         $this->instance = $instanceUuid;
@@ -57,10 +55,6 @@ class DbLogger implements LogWriterWithContext, EventEmitterInterface
             return;
         }
         $timestamp = Util::currentTimestamp();
-        while ($timestamp <= $this->lastTs) {
-            $timestamp++;
-        }
-        $this->lastTs = $timestamp;
 
         if ($this->db === null) {
             $this->queue->push([
@@ -85,7 +79,7 @@ class DbLogger implements LogWriterWithContext, EventEmitterInterface
             'instance_uuid' => $this->instance,
             'ts_create'     => $timestamp,
             'pid'           => $this->pid,
-            'fqdn'         => $this->fqdn,
+            'fqdn'          => $this->fqdn,
             'level'         => $level,
             'message'       => $message,
         ];

--- a/schema/mysql-migrations/upgrade_59.sql
+++ b/schema/mysql-migrations/upgrade_59.sql
@@ -1,5 +1,11 @@
-ALTER TABLE vspheredb_daemonlog
-  ADD PRIMARY KEY (instance_uuid, ts_create);
+-- The addition of a primary key on (instance_uuid, ts_create) will not be applied for now.
+-- This is due to the possibility of existing duplicates in the table, which could result in
+-- errors if the key were added to already populated tables. The comment helps track this change
+-- for people who might not be on the latest release but instead are using the master branch,
+-- and might have already imported the current state of the table before the key is added.
+
+-- ALTER TABLE vspheredb_daemonlog
+--   ADD PRIMARY KEY (instance_uuid, ts_create);
 
 INSERT INTO vspheredb_schema_migration
   (schema_version, migration_time)

--- a/schema/mysql.sql
+++ b/schema/mysql.sql
@@ -91,7 +91,7 @@ CREATE TABLE vspheredb_daemonlog (
     'emergency'
   ) NOT NULL,
   message MEDIUMTEXT NOT NULL,
-  PRIMARY KEY (instance_uuid, ts_create),
+--  PRIMARY KEY (instance_uuid, ts_create),
   INDEX idx_time (ts_create)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_bin;
 


### PR DESCRIPTION
Remove primary key for daemon logs table. The addition of the primary key can cause problems for populated tables.

Refs #558