### PR TITLE
Empty table before adding primary key

### DIFF
--- a/schema/mysql-migrations/upgrade_59.sql
+++ b/schema/mysql-migrations/upgrade_59.sql
@@ -1,3 +1,5 @@
+DELETE FROM vspheredb_daemonlog;
+
 ALTER TABLE vspheredb_daemonlog
   ADD PRIMARY KEY (instance_uuid, ts_create);
 


### PR DESCRIPTION
The addition of the primary key can cause problems for populated tables due to duplicate entries. Therefore we delete the existing data from 'vspheredb_daemonlog' table before adding the primary key.

Refs #559
Fixes #558