### PR TITLE
Bring parent uuids in correct order

### DIFF
--- a/library/Vspheredb/Monitoring/Rule/MonitoringRulesTree.php
+++ b/library/Vspheredb/Monitoring/Rule/MonitoringRulesTree.php
@@ -88,8 +88,7 @@ class MonitoringRulesTree
     public function getInheritedSettingsFor(BaseDbObject $object): InheritedSettings
     {
         $uuid = $object->object()->get('parent_uuid');
-        $parents = $this->listParentUuidsFor($uuid);
-        $parents[] = $uuid;
+        $parents = [$uuid, ...$this->listParentUuidsFor($uuid)];
 
         return InheritedSettings::loadForUuids($parents, $this, $this->db);
     }


### PR DESCRIPTION
The uuid of the nearest parent was checked last but had to be checked first. This resulted in a bug that caused the monitoring rules of the leaf notes to be overwritten by those of the parents.

Fixes #527 