### PR TITLE
Sync datastore disk metrics to Influx

### DIFF
--- a/library/Vspheredb/Daemon/PerfDataSync.php
+++ b/library/Vspheredb/Daemon/PerfDataSync.php
@@ -12,12 +12,14 @@ use Icinga\Module\Vspheredb\PerformanceData\InfluxConnectionForVcenterLoader;
 use Icinga\Module\Vspheredb\PerformanceData\MetricCSVToInfluxDataPoint;
 use Icinga\Module\Vspheredb\Polling\PerformanceCounterLookup\CounterLookup;
 use Icinga\Module\Vspheredb\Polling\PerformanceCounterLookup\CounterMap;
+use Icinga\Module\Vspheredb\Polling\PerformanceCounterLookup\DatastoreCounterLookup;
 use Icinga\Module\Vspheredb\Polling\PerformanceCounterLookup\HostCounterLookup;
 use Icinga\Module\Vspheredb\Polling\PerformanceCounterLookup\HostNetworkCounterLookup;
 use Icinga\Module\Vspheredb\Polling\PerformanceCounterLookup\VmCounterLookup;
 use Icinga\Module\Vspheredb\Polling\PerformanceCounterLookup\VmDiskCounterLookup;
 use Icinga\Module\Vspheredb\Polling\PerformanceCounterLookup\VmNetworkCounterLookup;
 use Icinga\Module\Vspheredb\Polling\PerformanceQuerySpecHelper;
+use Icinga\Module\Vspheredb\Polling\PerformanceSet\DatastoreDiskPerformanceSet;
 use Icinga\Module\Vspheredb\Polling\PerformanceSet\HostCpuPerformanceSet;
 use Icinga\Module\Vspheredb\Polling\PerformanceSet\HostMemoryPerformanceSet;
 use Icinga\Module\Vspheredb\Polling\PerformanceSet\HostNetworkPerformanceSet;
@@ -241,6 +243,10 @@ class PerfDataSync implements DaemonTask
 
         $counterLookup = new HostNetworkCounterLookup($db);
         $set = new HostNetworkPerformanceSet();
+        $this->fetchPerf($db, $uuid, $set, $counterLookup, $count);
+
+        $counterLookup = new DatastoreCounterLookup($db);
+        $set = new DatastoreDiskPerformanceSet();
         $this->fetchPerf($db, $uuid, $set, $counterLookup, $count);
     }
 

--- a/library/Vspheredb/Polling/PerformanceCounterLookup/DatastoreCounterLookup.php
+++ b/library/Vspheredb/Polling/PerformanceCounterLookup/DatastoreCounterLookup.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Icinga\Module\Vspheredb\Polling\PerformanceCounterLookup;
+
+use Ramsey\Uuid\UuidInterface;
+
+class DatastoreCounterLookup extends DefaultCounterLookup
+{
+    protected $objectKey = 'ds_moref';
+
+    protected $tagColumns = [
+        'ds_uuid'  => 'o.uuid',
+        'ds_moref' => 'o.moref',
+        'ds_name'  => 'o.object_name'
+    ];
+
+    protected function prepareInstancesQuery(UuidInterface $vCenterUuid = null)
+    {
+        return $this->prepareBaseQuery($vCenterUuid)
+            ->columns([
+                'o.moref',
+                // Applying the same workaround as in HostCounterLookup to avoid exceptions in our code.
+                // Ideally, we would address the underlying issue, but resolving it isn't worth the effort right now.
+                'nix' => '(NULL)'
+            ]);
+    }
+
+    protected function prepareBaseQuery(UuidInterface $vCenterUuid = null)
+    {
+        $query = $this->db->select()->from(['o' => 'object'], [])
+            ->join(['ds' => 'datastore'], 'o.uuid = ds.uuid', []);
+
+        if ($vCenterUuid) {
+            $query->where('o.vcenter_uuid = ?', $vCenterUuid->getBytes());
+        }
+
+        return $query;
+    }
+}

--- a/library/Vspheredb/Polling/PerformanceSet/DatastoreDiskPerformanceSet.php
+++ b/library/Vspheredb/Polling/PerformanceSet/DatastoreDiskPerformanceSet.php
@@ -5,12 +5,16 @@ namespace Icinga\Module\Vspheredb\Polling\PerformanceSet;
 class DatastoreDiskPerformanceSet extends DefaultPerformanceSet
 {
     protected $name = 'DatastoreDisk';
+
     protected $objectType = 'Datastore';
+
     protected $countersGroup = 'disk';
+
     protected $counters = [
         'capacity',
-        'used',
-        'provisioned',
         'deltaused',
+        'provisioned',
+        'usage',
+        'used'
     ];
 }


### PR DESCRIPTION
Add counters for following performance data metrics:
- disk.usage.none
- disk.usage.average
- disk.usage.minimum
- disk.usage.maximum
- disk.used.latest
- disk.deltaused.latest