### PR TITLE
"Best wins" was only evaluated when both cases were already "worst"

### DIFF
--- a/library/Vspheredb/Monitoring/Rule/Definition/MemoryUsageHelper.php
+++ b/library/Vspheredb/Monitoring/Rule/Definition/MemoryUsageHelper.php
@@ -62,7 +62,7 @@ class MemoryUsageHelper
             $mbState->raiseState(State::CRITICAL);
         }
 
-        if ($mbState->isProblem() && $percentState->isProblem()) {
+        if ($mbState->isProblem() || $percentState->isProblem()) {
             if ($settings->get('threshold_precedence') === 'worst_wins') {
                 $state->raiseState(State::getWorst($percentState, $mbState));
             } else {


### PR DESCRIPTION
I believe the AND logic is wrong here. When only either of the states (relative OR absolute) are in "isProblem" state, the *best_wins*/*worst_wins* logic is not evaluated.
Instead the following code gets executed in the *else* branch:
````
            $state->raiseState($percentState);
            $state->raiseState($mbState);
````
This will raise a state in any case - even if *best_wins* has been set!