### PR TITLE
"Best wins" was only evaluated when both cases were already "worst"

### DIFF
--- a/library/Vspheredb/Monitoring/Rule/Definition/MemoryUsageHelper.php
+++ b/library/Vspheredb/Monitoring/Rule/Definition/MemoryUsageHelper.php
@@ -62,7 +62,7 @@ class MemoryUsageHelper
             $mbState->raiseState(State::CRITICAL);
         }
 
-        if ($mbState->isProblem() && $percentState->isProblem()) {
+        if ($mbState->isProblem() || $percentState->isProblem()) {
             if ($settings->get('threshold_precedence') === 'worst_wins') {
                 $state->raiseState(State::getWorst($percentState, $mbState));
             } else {


### PR DESCRIPTION
If *absolute* **AND** *percentage* are isProblem, then there is no point in evaluating "best_wins"

Hence, it should be *absolute* **OR** *percentage* isProblem and then see if we want to match "worst_wins" or "best_wins".
