### PR TITLE
Replace `RingCentral` usage with `GuzzleHttp`

### DIFF
--- a/application/clicommands/PerfdataconsumerCommand.php
+++ b/application/clicommands/PerfdataconsumerCommand.php
@@ -7,7 +7,7 @@ use gipfl\Web\Form;
 use gipfl\ZfDbStore\ZfDbStore;
 use Icinga\Data\ResourceFactory;
 use Icinga\Module\Vspheredb\Web\Form\PerfdataConsumerForm;
-use RingCentral\Psr7\ServerRequest;
+use GuzzleHttp\Psr7\ServerRequest;
 
 class PerfdataconsumerCommand extends Command
 {

--- a/library/Vspheredb/Api/Protocol/ClientEncoder.php
+++ b/library/Vspheredb/Api/Protocol/ClientEncoder.php
@@ -3,7 +3,7 @@
 namespace Icinga\Module\Vspheredb\Api\Protocol;
 
 use SoapClient;
-use RingCentral\Psr7\Request;
+use GuzzleHttp\Psr7\Request;
 use SoapFault;
 
 /**

--- a/library/Vspheredb/Web/Widget/GrafanaVmPanel.php
+++ b/library/Vspheredb/Web/Widget/GrafanaVmPanel.php
@@ -6,7 +6,7 @@ use Icinga\Module\Vspheredb\DbObject\ManagedObject;
 use ipl\Html\Html;
 use ipl\Html\HtmlDocument;
 
-use function RingCentral\Psr7\build_query;
+use function GuzzleHttp\Psr7\build_query;
 
 /**
  * This is just an experiment. Disabled, as it is pretty slow


### PR DESCRIPTION
Regarding https://github.com/Icinga/icingaweb2-module-vspheredb/issues/599, we debugged a hanging initial logout session to this point in *library/Vspheredb/Api/Protocol/ClientEncoder.php* where we were able to catch this error:
````
Declaration of RingCentral\Psr7\Request::getRequestTarget() must be compatible with Psr\Http\Message\RequestInterface::getRequestTarget(): string
````
After changing the request library to **GuzzleHttp** (which gets used in icingaweb2-module-director), it worked.
To be sure all occurrences have been replaced.

fixes #599 