### PR TITLE
diskObjectId is required to create vm_disk

### DIFF
--- a/library/Vspheredb/Polling/SyncTask/VmHardwareSyncTask.php
+++ b/library/Vspheredb/Polling/SyncTask/VmHardwareSyncTask.php
@@ -40,6 +40,7 @@ class VmHardwareSyncTask extends SyncTask
             'addressType',
 
             // Disk:
+            'diskObjectId',
             // 'backing', // exists in Nic: too
             'capacityInBytes',
             'split',


### PR DESCRIPTION
closes https://github.com/Icinga/icingaweb2-module-vspheredb/issues/604
