### PR TITLE
Add Dell Networker (EMC vProxy) and Cohesity Backup support

### DIFF
--- a/library/Vspheredb/Addon/CohesityBackup.php
+++ b/library/Vspheredb/Addon/CohesityBackup.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Icinga\Module\Vspheredb\Addon;
+
+use Icinga\Module\Vspheredb\DbObject\CustomValues;
+
+class CohesityBackup extends SimpleBackupTool
+{
+    public const CV_BACKUP_TIME = 'Last Cohesity Backup Attempt Time';
+    public const CV_BACKUP_STATUS = 'Last Cohesity Backup Status';
+
+    protected $customValues = [
+        self::CV_BACKUP_TIME,
+        self::CV_BACKUP_STATUS,
+    ];
+
+    public function getName()
+    {
+        return 'Cohesity Backup';
+    }
+
+    protected function parseCustomValues(CustomValues $values)
+    {
+        $attributes = [];
+
+        if ($values->has(self::CV_BACKUP_TIME)) {
+            $timeStr = $values->get(self::CV_BACKUP_TIME);
+            // Format: 2026/01/30-15:10:26-GMT+0100
+            $normalized = preg_replace(
+                '/^(\d{4})\/(\d{2})\/(\d{2})-(\d{2}:\d{2}:\d{2})-GMT([+-]\d{4})$/',
+                '$1-$2-$3 $4 $5',
+                $timeStr
+            );
+            $attributes['Time'] = strtotime($normalized);
+        }
+
+        if ($values->has(self::CV_BACKUP_STATUS)) {
+            $attributes['Status'] = $values->get(self::CV_BACKUP_STATUS);
+        }
+
+        $this->lastAttributes = $attributes;
+    }
+}

--- a/library/Vspheredb/Addon/DellNetworker.php
+++ b/library/Vspheredb/Addon/DellNetworker.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Icinga\Module\Vspheredb\Addon;
+
+use Icinga\Module\Vspheredb\DbObject\CustomValues;
+
+class DellNetworker extends SimpleBackupTool
+{
+    public const CV_LAST_BACKUP = 'Last EMC vProxy Backup';
+
+    protected $customValues = [
+        self::CV_LAST_BACKUP,
+    ];
+
+    public function getName()
+    {
+        return 'Dell Networker (EMC vProxy)';
+    }
+
+    protected function parseCustomValues(CustomValues $values)
+    {
+        if (!$values->has(self::CV_LAST_BACKUP)) {
+            return;
+        }
+
+        $string = $values->get(self::CV_LAST_BACKUP);
+        $attributes = [];
+
+        // Format: Backup Server=backup01.local, Policy=RZ, Workflow=vm_day_backup, ...
+        foreach (preg_split('/,\s*/', $string) as $part) {
+            if (preg_match('/^([^=]+)=(.*)$/', trim($part), $m)) {
+                $key = trim($m[1]);
+                $value = trim($m[2]);
+
+                if (in_array($key, ['StartTime', 'EndTime'])) {
+                    $attributes[$key] = strtotime($value);
+                } else {
+                    $attributes[$key] = $value;
+                }
+            }
+        }
+
+        if (isset($attributes['EndTime'])) {
+            $attributes['Time'] = $attributes['EndTime'];
+        }
+
+        $this->lastAttributes = $attributes;
+    }
+}

--- a/library/Vspheredb/Addon/SimpleBackupTool.php
+++ b/library/Vspheredb/Addon/SimpleBackupTool.php
@@ -2,6 +2,8 @@
 
 namespace Icinga\Module\Vspheredb\Addon;
 
+use gipfl\IcingaWeb2\Widget\NameValueTable;
+use Icinga\Date\DateFormatter;
 use Icinga\Module\Vspheredb\DbObject\CustomValues;
 use Icinga\Module\Vspheredb\DbObject\VirtualMachine;
 use RuntimeException;
@@ -151,5 +153,31 @@ abstract class SimpleBackupTool implements BackupTool
         foreach ($this->customValues as $name) {
             $values->remove($name);
         }
+    }
+
+    /**
+     * Returns a generic info renderer for backup tools.
+     * Override this method for custom rendering.
+     *
+     * @return NameValueTable|null
+     */
+    public function getInfoRenderer()
+    {
+        $attributes = $this->getAttributes();
+
+        if ($attributes === null) {
+            return null;
+        }
+
+        $table = new NameValueTable();
+
+        foreach ($attributes as $key => $value) {
+            if (is_int($value) && preg_match('/time/i', $key)) {
+                $value = DateFormatter::formatDateTime($value);
+            }
+            $table->addNameValueRow($key, $value);
+        }
+
+        return $table;
     }
 }

--- a/library/Vspheredb/Web/Widget/CustomValueDetails.php
+++ b/library/Vspheredb/Web/Widget/CustomValueDetails.php
@@ -4,6 +4,8 @@ namespace Icinga\Module\Vspheredb\Web\Widget;
 
 use gipfl\Translation\TranslationHelper;
 use gipfl\Web\Table\NameValueTable;
+use Icinga\Module\Vspheredb\Addon\CohesityBackup;
+use Icinga\Module\Vspheredb\Addon\DellNetworker;
 use Icinga\Module\Vspheredb\Addon\IbmSpectrumProtect;
 use Icinga\Module\Vspheredb\Addon\SimpleBackupTool;
 use Icinga\Module\Vspheredb\Addon\NetBackup;
@@ -59,6 +61,8 @@ class CustomValueDetails extends HtmlDocument
     protected function stripBackupToolCustomValues(CustomValues $values)
     {
         $tools = [
+            new CohesityBackup(),
+            new DellNetworker(),
             new IbmSpectrumProtect(),
             new NetBackup(),
             new VRangerBackup(),

--- a/library/Vspheredb/Web/Widget/Vm/BackupToolInfo.php
+++ b/library/Vspheredb/Web/Widget/Vm/BackupToolInfo.php
@@ -4,6 +4,8 @@ namespace Icinga\Module\Vspheredb\Web\Widget\Vm;
 
 use gipfl\Translation\TranslationHelper;
 use Icinga\Module\Vspheredb\Addon\BackupTool;
+use Icinga\Module\Vspheredb\Addon\CohesityBackup;
+use Icinga\Module\Vspheredb\Addon\DellNetworker;
 use Icinga\Module\Vspheredb\Addon\IbmSpectrumProtect;
 use Icinga\Module\Vspheredb\Addon\NetBackup;
 use Icinga\Module\Vspheredb\Addon\VeeamBackup;
@@ -55,6 +57,8 @@ class BackupToolInfo extends HtmlDocument
     protected function getBackupTools()
     {
         return [
+            new CohesityBackup(),
+            new DellNetworker(),
             new IbmSpectrumProtect(),
             new NetBackup(),
             new VeeamBackup(),


### PR DESCRIPTION
## Summary

- **Dell Networker (EMC vProxy)**: Parses `Last EMC vProxy Backup` custom attribute
- **Cohesity Backup**: Parses `Last Cohesity Backup Attempt Time` and `Last Cohesity Backup Status` custom attributes
- **Generic Renderer**: Extends `SimpleBackupTool` with `getInfoRenderer()` method, eliminating the need for separate `*RunDetails.php` widgets

## Custom Attribute Formats

### Dell Networker
```
Last EMC vProxy Backup    Backup Server=backup01.local, Policy=RZ, Workflow=vm_day_backup, Action=backup, JobId=71687619, StartTime=2024-06-10T19:59:13Z, EndTime=2024-06-10T19:59:38Z
```

### Cohesity
```
Last Cohesity Backup Attempt Time    2026/01/30-15:10:26-GMT+0100
Last Cohesity Backup Status          Success
```

## Changes

| File | Change |
|------|--------|
| `Addon/DellNetworker.php` | New file |
| `Addon/CohesityBackup.php` | New file |
| `Addon/SimpleBackupTool.php` | Added generic `getInfoRenderer()` |
| `Widget/Vm/BackupToolInfo.php` | Register new tools |
| `Widget/CustomValueDetails.php` | Register new tools |

## Test Plan

- [ ] Verify Dell Networker backup info displays correctly for VMs with the custom attribute
- [ ] Verify Cohesity backup info displays correctly for VMs with the custom attributes
- [ ] Verify existing backup tools (Veeam, NetBackup, IBM Spectrum, vRanger) still work

Closes #552

🤖 Generated with [Claude Code](https://claude.ai/code)