### PR TITLE
Remove unused property `$loop`

### DIFF
--- a/application/clicommands/Command.php
+++ b/application/clicommands/Command.php
@@ -15,14 +15,10 @@ use Icinga\Cli\Command as CliCommand;
 use Icinga\Module\Vspheredb\Configuration;
 use Icinga\Module\Vspheredb\Daemon\RemoteClient;
 use React\EventLoop\Loop;
-use React\EventLoop\LoopInterface;
 use React\Stream\WritableResourceStream;
 
 class Command extends CliCommand
 {
-    /** @var LoopInterface */
-    private $loop;
-
     private $loopStarted = false;
 
     protected $logger;


### PR DESCRIPTION
Since [db4e52f](https://github.com/icinga/icingaweb2-module-vspheredb/commit/db4e52f) the `loop()` method does return `Loop::get()` directly instead of the `$loop` property. The property is now unused and therefore removed.

refs #609 