### PR TITLE
Persistent daemon log level

### DIFF
--- a/application/clicommands/Command.php
+++ b/application/clicommands/Command.php
@@ -24,7 +24,7 @@ class Command extends CliCommand
 {
     private $loopStarted = false;
 
-    protected $logger;
+    protected Logger $logger;
 
     /** @var RemoteClient */
     protected $remoteClient;

--- a/application/clicommands/DaemonCommand.php
+++ b/application/clicommands/DaemonCommand.php
@@ -5,9 +5,12 @@
 
 namespace Icinga\Module\Vspheredb\Clicommands;
 
+use gipfl\Log\Filter\LogLevelFilter;
 use gipfl\SimpleDaemon\Daemon;
 use Icinga\Module\Vspheredb\Daemon\RpcNamespace\RpcNamespaceProcess;
 use Icinga\Module\Vspheredb\Daemon\VsphereDbDaemon;
+use Icinga\Module\Vspheredb\Db;
+use Throwable;
 
 class DaemonCommand extends Command
 {
@@ -23,6 +26,7 @@ class DaemonCommand extends Command
         $this->assertRequiredExtensionsAreLoaded();
         $this->assertNoVcenterParam();
         $daemon = new Daemon();
+        $this->eventuallyApplyConfiguredLogLevel();
         $daemon->setLogger($this->logger);
         $vSphereDb = new VsphereDbDaemon();
         $vSphereDb->on(RpcNamespaceProcess::ON_RESTART, function () use ($daemon) {
@@ -31,6 +35,39 @@ class DaemonCommand extends Command
         $daemon->attachTask($vSphereDb);
         $daemon->run($this->loop());
         $this->eventuallyStartMainLoop();
+    }
+
+    protected function eventuallyApplyConfiguredLogLevel(): void
+    {
+        // Setting the log level via CLI flags has higher precedence than database config
+        if ($this->isVerbose || $this->isDebugging) {
+            return;
+        }
+
+        $db = null;
+        try {
+            $db = Db::newConfiguredInstance()->getDbAdapter();
+            $level = $db->fetchOne(
+                $db->select()
+                    ->from('daemon_config', ['value'])
+                    ->where('`key` = ?', 'log_level')
+            );
+            if (! is_string($level) || $level === '') {
+                return;
+            }
+
+            $newFilter = new LogLevelFilter($level);
+            $this->logger->addFilter($newFilter);
+            foreach ($this->logger->getFilters() as $filter) {
+                if ($filter instanceof LogLevelFilter && $filter !== $newFilter) {
+                    $this->logger->removeFilter($filter);
+                }
+            }
+        } catch (Throwable) {
+            // Keep current log level if DB config is not available yet.
+        } finally {
+            $db?->closeConnection();
+        }
     }
 
     protected function assertNoVcenterParam()

--- a/application/controllers/DaemonController.php
+++ b/application/controllers/DaemonController.php
@@ -45,7 +45,7 @@ class DaemonController extends Controller
 
     protected function prepareLogSettings()
     {
-        $logLevelForm = new LogLevelForm($this->remoteClient(), $this->loop());
+        $logLevelForm = new LogLevelForm($this->remoteClient(), $this->loop(), $this->db()->getDbAdapter());
         $logLevelForm->on($logLevelForm::ON_SUCCESS, function () {
             $this->redirectNow($this->url());
         });

--- a/library/Vspheredb/Daemon/RpcNamespace/RpcNamespaceLogger.php
+++ b/library/Vspheredb/Daemon/RpcNamespace/RpcNamespaceLogger.php
@@ -43,14 +43,10 @@ class RpcNamespaceLogger
             $this->logger->notice("Will change the log level to '$level'");
         }
         $this->logger->addFilter($newFilter);
-        $remove = [];
         foreach ($this->logger->getFilters() as $filter) {
             if ($filter instanceof LogLevelFilter && $filter !== $newFilter) {
-                $remove[] = $filter;
+                $this->logger->removeFilter($filter);
             }
-        }
-        foreach ($remove as $filter) {
-            $this->logger->removeFilter($filter);
         }
         if ($newFilter->wants('notice', '')) {
             $this->logger->notice("Changed log level to '$level'");

--- a/library/Vspheredb/Daemon/VsphereDbDaemon.php
+++ b/library/Vspheredb/Daemon/VsphereDbDaemon.php
@@ -171,77 +171,79 @@ class VsphereDbDaemon implements DaemonTask, SystemdAwareTask, LoggerAwareInterf
                 $this->daemonState->getComponentState($component)
             ));
         }
-        if ($component === self::COMPONENT_DB) {
-            if ($formerState === self::STATE_READY) {
-                $this->stopConfigWatch();
-                $this->stopComponent(self::COMPONENT_API);
-                $this->stopComponent(self::COMPONENT_LOCALDB);
-            } elseif ($currentState === self::STATE_IDLE) {
-                $this->runConfigWatch();
-            } elseif ($currentState === self::STATE_READY) {
-                $this->setLocalDbState(self::STATE_STARTING);
-            }
-            if ($currentState === self::STATE_FAILED) {
-                $this->loop->addTimer(10, function () {
-                    $this->stopDbProcess();
+        switch ($component) {
+            case self::COMPONENT_DB:
+                if ($formerState === self::STATE_READY) {
                     $this->stopConfigWatch();
-                    if ($this->daemonState->getComponentState(self::COMPONENT_DB) === self::STATE_FAILED) {
-                        $this->initializeDbProcess();
-                    }
-                });
-            }
-        }
-        if ($component === self::COMPONENT_LOCALDB) {
-            if ($formerState === self::STATE_READY) {
-                $this->stopComponent(self::COMPONENT_API);
-            }
-            switch ($currentState) {
-                case self::STATE_STARTING:
-                    $this->reconnectToDb();
-                    break;
-                case self::STATE_FAILED:
-                    $this->logger->error('Failed. Will try to reconnect to the Database');
-                    $this->eventuallyDisconnectFromDb();
-                    $delay = $this->delayOnFailed;
-                    $this->logger->warning("Failed. Reconnecting in {$delay}s");
-                    $this->loop->addTimer($delay, function () {
-                        if ($this->getLocalDbState() === self::STATE_FAILED) {
-                            $this->setLocalDbState(self::STATE_STARTING);
+                    $this->stopComponent(self::COMPONENT_API);
+                    $this->stopComponent(self::COMPONENT_LOCALDB);
+                } elseif ($currentState === self::STATE_IDLE) {
+                    $this->runConfigWatch();
+                } elseif ($currentState === self::STATE_READY) {
+                    $this->setLocalDbState(self::STATE_STARTING);
+                }
+                if ($currentState === self::STATE_FAILED) {
+                    $this->loop->addTimer(10, function () {
+                        $this->stopDbProcess();
+                        $this->stopConfigWatch();
+                        if ($this->daemonState->getComponentState(self::COMPONENT_DB) === self::STATE_FAILED) {
+                            $this->initializeDbProcess();
                         }
                     });
-                    break;
-                case self::STATE_READY:
-                    $this->setApiState(self::STATE_STARTING);
-                    break;
-                case self::STATE_STOPPING:
-                    $this->eventuallyDisconnectFromDb();
+                }
+                break;
+            case self::COMPONENT_LOCALDB:
+                if ($formerState === self::STATE_READY) {
                     $this->stopComponent(self::COMPONENT_API);
-                    $this->setLocalDbState(self::STATE_STOPPED);
-                    break;
-            }
-        }
-        if ($component === self::COMPONENT_API) {
-            switch ($currentState) {
-                case self::STATE_STARTING:
-                    $this->apiConnectionHandler->run($this->loop);
-                    $this->setApiState(self::STATE_READY);
-                    break;
-                case self::STATE_READY:
-                    $this->refreshConfiguredServers();
-                    $this->daemonState->setState(self::STATE_READY);
-                    break;
-                case self::STATE_FAILED:
-                    $this->logger->error('[api] failed');
+                }
+                switch ($currentState) {
+                    case self::STATE_STARTING:
+                        $this->reconnectToDb();
+                        break;
+                    case self::STATE_FAILED:
+                        $this->logger->error('Failed. Will try to reconnect to the Database');
+                        $this->eventuallyDisconnectFromDb();
+                        $delay = $this->delayOnFailed;
+                        $this->logger->warning("Failed. Reconnecting in {$delay}s");
+                        $this->loop->addTimer($delay, function () {
+                            if ($this->getLocalDbState() === self::STATE_FAILED) {
+                                $this->setLocalDbState(self::STATE_STARTING);
+                            }
+                        });
+                        break;
+                    case self::STATE_READY:
+                        $this->setApiState(self::STATE_STARTING);
+                        break;
+                    case self::STATE_STOPPING:
+                        $this->eventuallyDisconnectFromDb();
+                        $this->stopComponent(self::COMPONENT_API);
+                        $this->setLocalDbState(self::STATE_STOPPED);
+                        break;
+                }
+                break;
+            case self::COMPONENT_API:
+                switch ($currentState) {
+                    case self::STATE_STARTING:
+                        $this->apiConnectionHandler->run($this->loop);
+                        $this->setApiState(self::STATE_READY);
+                        break;
+                    case self::STATE_READY:
+                        $this->refreshConfiguredServers();
+                        $this->daemonState->setState(self::STATE_READY);
+                        break;
+                    case self::STATE_FAILED:
+                        $this->logger->error('[api] failed');
                     // Intentional fall-through:
                     // no break
-                case self::STATE_STOPPING:
-                    if ($this->apiConnectionHandler) {
-                        $this->apiConnectionHandler->stop();
-                    }
-                    $this->stopAllApiTasks();
-                    $this->setApiState(self::STATE_STOPPED);
-                    break;
-            }
+                    case self::STATE_STOPPING:
+                        if ($this->apiConnectionHandler) {
+                            $this->apiConnectionHandler->stop();
+                        }
+                        $this->stopAllApiTasks();
+                        $this->setApiState(self::STATE_STOPPED);
+                        break;
+                }
+                break;
         }
     }
 

--- a/library/Vspheredb/Daemon/VsphereDbDaemon.php
+++ b/library/Vspheredb/Daemon/VsphereDbDaemon.php
@@ -121,7 +121,6 @@ class VsphereDbDaemon implements DaemonTask, SystemdAwareTask, LoggerAwareInterf
         $this->loop = $loop;
         $logger = $this->logger;
         $this->daemonState = $this->initializeDaemonState();
-        $this->setInitialDaemonState();
         $this->detectProcessInfo();
         $this->initializeDbLogger($logger); // TODO: move to sub process. Hint: needs no DB, has a queue
         $this->prepareApi($loop, $logger);
@@ -155,15 +154,10 @@ class VsphereDbDaemon implements DaemonTask, SystemdAwareTask, LoggerAwareInterf
             }
             $this->componentStates = $daemonState->getComponentStates();
         });
-
-        return $daemonState;
-    }
-
-    protected function setInitialDaemonState()
-    {
-        $daemonState = $this->daemonState;
         $daemonState->setProcessTitle(self::PROCESS_NAME);
         $daemonState->setState(self::STATE_STARTING);
+
+        return $daemonState;
     }
 
     protected function onComponentChange($component, $formerState, $currentState)

--- a/library/Vspheredb/Web/Form/LogLevelForm.php
+++ b/library/Vspheredb/Web/Form/LogLevelForm.php
@@ -12,6 +12,7 @@ use ipl\Html\FormElement\SelectElement;
 use ipl\I18n\Translation;
 use Psr\Log\LogLevel;
 use React\EventLoop\LoopInterface;
+use Zend_Db_Adapter_Abstract;
 
 use function React\Async\await;
 
@@ -25,13 +26,17 @@ class LogLevelForm extends InlineForm
     /** @var LoopInterface */
     protected $loop;
 
+    /** @var Zend_Db_Adapter_Abstract */
+    protected Zend_Db_Adapter_Abstract $db;
+
     /** @var boolean */
     protected $talkedToSocket;
 
-    public function __construct(RemoteClient $client, LoopInterface $loop)
+    public function __construct(RemoteClient $client, LoopInterface $loop, Zend_Db_Adapter_Abstract $db)
     {
         $this->client = $client;
         $this->loop = $loop;
+        $this->db = $db;
     }
 
     public function talkedToSocket()
@@ -66,7 +71,24 @@ class LogLevelForm extends InlineForm
 
     protected function onSuccess()
     {
-        await($this->client->request('logger.setLogLevel', ['level' => $this->getValue('log_level')]));
+        $logLevel = $this->getValue('log_level');
+        await(
+            $this->client->request('logger.setLogLevel', ['level' => $logLevel])
+                ->then(function () use ($logLevel) {
+                    $query = $this->db->select()
+                        ->from('daemon_config', ['key'])
+                        ->where('`key` = ?', 'log_level');
+                    if ($this->db->query($query)->rowCount()) {
+                        $this->db->update(
+                            'daemon_config',
+                            ['value' => $logLevel],
+                            $this->db->quoteInto('`key` = ?', 'log_level')
+                        );
+                    } else {
+                        $this->db->insert('daemon_config', ['`key`' => 'log_level', 'value' => $logLevel]);
+                    }
+                })
+        );
     }
 
     protected function listLogLevels()

--- a/schema/mysql-migrations/upgrade_64.sql
+++ b/schema/mysql-migrations/upgrade_64.sql
@@ -1,0 +1,8 @@
+CREATE TABLE daemon_config (
+  `key` ENUM('log_level') PRIMARY KEY,
+  value VARCHAR(255) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_bin;
+
+INSERT INTO vspheredb_schema_migration
+  (schema_version, migration_time)
+  VALUES (64, NOW());

--- a/schema/mysql.sql
+++ b/schema/mysql.sql
@@ -998,6 +998,11 @@ CREATE TABLE tagging_object_tag (
 --   vm_id BIGINT(20) UNSIGNED AUTO_INCREMENT NOT NULL,
 -- );
 
+CREATE TABLE daemon_config (
+    `key` ENUM('log_level') PRIMARY KEY,
+    value VARCHAR(255) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_bin;
+
 INSERT INTO vspheredb_schema_migration
   (schema_version, migration_time)
-  VALUES (63, NOW());
+  VALUES (64, NOW());


### PR DESCRIPTION
### Problem
Till now the daemon log level could be set in Icinga Web, but it was **not persisted anywhere**.

### Changes
The chosen value in the Icinga Web form will now be persisted to the database. The daemon queries the database on startup and applies it to the logger under following conditions:
1. A log level is set in the database.
2. No log level flag is passed to the daemon run command (like `--verbose` or `--debug`).

Additionally some minor code improvements have been done.