### PR TITLE
Fix import and display of multiple tags from the same category

### DIFF
--- a/library/Vspheredb/Db/TagLookup.php
+++ b/library/Vspheredb/Db/TagLookup.php
@@ -54,9 +54,9 @@ class TagLookup
                 $result[$categoryName] = $tag->get('name');
             } else {
                 if (isset($result[$categoryName])) {
-                    $result[$categoryName] = [$tag->get('name')];
-                } else {
                     $result[$categoryName][] = $tag->get('name');
+                } else {
+                    $result[$categoryName] = [$tag->get('name')];
                 }
             }
         }

--- a/library/Vspheredb/Web/Widget/TaggingDetails.php
+++ b/library/Vspheredb/Web/Widget/TaggingDetails.php
@@ -52,6 +52,7 @@ class TaggingDetails extends HtmlDocument
             ->join(['tt' => TaggingTag::TABLE], 'tt.category_uuid = tc.uuid', [])
             ->join(['tot' => TaggingObjectTag::TABLE], 'tot.tag_uuid = tt.uuid', [])
             ->where('tot.object_uuid = ?', $object->get('uuid'))
+            ->group('tc.uuid')
             ->order('tc.name');
         $this->categories = TaggingCategory::loadAll($connection, $where);
         // $this->setDemoTags();


### PR DESCRIPTION
When an object had more than one tag from a MULTIPLE-cardinality category, `TagLookup` silently discarded all but the last tag due to swapped `if`/`else` branches. `TaggingDetails` rendered the category row once per tag because the JOIN was not grouped. Swap the branches and add `GROUP BY tc.uuid` to fix both.

fixes #596