### PR TITLE
Add forward compatible return types

### DIFF
--- a/library/Vspheredb/Web/Form/PerfdataConsumerForm.php
+++ b/library/Vspheredb/Web/Form/PerfdataConsumerForm.php
@@ -56,7 +56,7 @@ class PerfdataConsumerForm extends ObjectForm
         $this->addButtons(isset($implementation), 'implementation');
     }
 
-    public function isValidEvent($event)
+    public function isValidEvent($event): bool
     {
         if ($event === self::ON_DELETE) {
             return true;

--- a/library/Vspheredb/Web/Form/VCenterShipMetricsForm.php
+++ b/library/Vspheredb/Web/Form/VCenterShipMetricsForm.php
@@ -121,7 +121,7 @@ class VCenterShipMetricsForm extends ObjectForm
         }
     }
 
-    public function isValidEvent($event)
+    public function isValidEvent($event): bool
     {
         if ($event === self::ON_DELETE) {
             return true;


### PR DESCRIPTION
Add bool return type to `PerfDataConsumerForm::isValidEvent()` and `VCenterShipMetricsForm::isValidEvent` to ensure compatibility with the upcoming strict type additions in [ipl-html](https://github.com/Icinga/ipl-html/pull/189) and [ipl-stdlib](https://github.com/Icinga/ipl-stdlib/pull/69).