### PR TITLE
Fix `getOption()` calls to use empty string instead of `null`

### DIFF
--- a/library/Vspheredb/Monitoring/Rule/RuleForm.php
+++ b/library/Vspheredb/Monitoring/Rule/RuleForm.php
@@ -170,7 +170,7 @@ class RuleForm extends Form
             } elseif ($optionValue === false) {
                 $optionValue = 'n';
             }
-            $element->getOption(null)->setContent(
+            $element->getOption('')->setContent(
                 implode(',', $element->getOption($optionValue)->getContent()) . $suffix
             );
         } elseif ($element instanceof TextElement || $element instanceof NumberElement) {

--- a/library/Vspheredb/Web/Form/InfluxDbConnectionForm.php
+++ b/library/Vspheredb/Web/Form/InfluxDbConnectionForm.php
@@ -178,7 +178,7 @@ class InfluxDbConnectionForm extends Form
         }
         $element = $this->getElement('api_version');
         assert($element instanceof SelectElement);
-        $autoOption = $element->getOption(null);
+        $autoOption = $element->getOption('');
         $autoOption->setLabel(\sprintf(
             $this->translate('Autodetect: %s API, Version is %s'),
             $apiVersion,


### PR DESCRIPTION
Replace null with '' in `SelectElement::getOption()`, since the placeholder options for select elements are keyed by an empty string, not null.