### PR TITLE
Release version 1.8.2

### DIFF
--- a/doc/01-Installation.md
+++ b/doc/01-Installation.md
@@ -58,7 +58,7 @@ existing module installation will be replaced, so this can be used for upgrades 
 
 ```shell
 # You can customize these settings, but we suggest to stick with our defaults:
-MODULE_VERSION="1.8.1"
+MODULE_VERSION="1.8.2"
 DAEMON_USER="icingavspheredb"
 DAEMON_GROUP="icingaweb2"
 ICINGAWEB_MODULEPATH="/usr/share/icingaweb2/modules"

--- a/doc/84-Changelog.md
+++ b/doc/84-Changelog.md
@@ -1,6 +1,30 @@
 <a id="Changelog"></a>Changelog
 ===============================
 
+v1.8.2
+------
+
+This is a maintenance release that fixes PHP 8.5 deprecation warnings caused by
+using `null` as an array offset, and an incompatibility with IPL HTML in
+`SelectElement::getOption()` calls.
+
+### Upgrading
+
+Packages are available as `icinga-vspheredb`. If you missed the packages
+introduced with v1.8.0, consider switching to them now. For non-package
+installations, please check our [Upgrade Script](01-Installation.md#modul-installation-or-upgrade).
+
+### Fixed issues
+* You can find issues and feature requests related to this release on our
+  [roadmap](https://github.com/Icinga/icingaweb2-module-vspheredb/milestone/21?closed=1)
+
+### PHP Support
+* FIX: No longer using `null` as array offset, which is deprecated in PHP 8.5
+
+### IPL Compatibility
+* FIX: `SelectElement::getOption()` now receives an empty string instead of
+  `null` for the placeholder option (#621)
+
 v1.8.1
 ------
 

--- a/library/Vspheredb/Monitoring/Rule/Definition/MemoryUsageHelper.php
+++ b/library/Vspheredb/Monitoring/Rule/Definition/MemoryUsageHelper.php
@@ -83,8 +83,8 @@ class MemoryUsageHelper
             'threshold_precedence' => ['select', [
                 'label' => $t->translate('Threshold/State Precedence'),
                 'options' => [
-                    null => $t->translate('- please choose -'),
-                    'best_wins'  => $t->translate('Better state wins'),
+                    '' => $t->translate('- please choose -'),
+                    'best_wins' => $t->translate('Better state wins'),
                     'worst_wins' => $t->translate('Worse state wins'),
                 ],
             ]],

--- a/library/Vspheredb/Monitoring/Rule/RuleForm.php
+++ b/library/Vspheredb/Monitoring/Rule/RuleForm.php
@@ -270,7 +270,7 @@ class RuleForm extends Form
     protected function addStateTriggerElement(string $name, $options = [])
     {
         $selectOptions = [
-            null => $this->translate('Not configured / Inherited'),
+            '' => $this->translate('Not configured / Inherited'),
             MonitoringStateTrigger::IGNORE => $this->translate('Do nothing'),
             MonitoringStateTrigger::RAISE_WARNING => $this->translate('Trigger a Warning state'),
             MonitoringStateTrigger::RAISE_CRITICAL => $this->translate('Trigger a Critical state'),

--- a/library/Vspheredb/Monitoring/Rule/RuleForm.php
+++ b/library/Vspheredb/Monitoring/Rule/RuleForm.php
@@ -170,7 +170,7 @@ class RuleForm extends Form
             } elseif ($optionValue === false) {
                 $optionValue = 'n';
             }
-            $element->getOption(null)->setContent(
+            $element->getOption('')->setContent(
                 implode(',', $element->getOption($optionValue)->getContent()) . $suffix
             );
         } elseif ($element instanceof TextElement || $element instanceof NumberElement) {

--- a/library/Vspheredb/ProvidedHook/Director/DataTypeMonitoringRule.php
+++ b/library/Vspheredb/ProvidedHook/Director/DataTypeMonitoringRule.php
@@ -26,8 +26,7 @@ class DataTypeMonitoringRule extends DataTypeHook
             $options[$set->getLabel()] = $current;
         }
         return $form->createElement('select', $name, [
-            'multiOptions' => [null => $form->translate('- please choose -')] +
-                $options,
+            'multiOptions' => ['' => $form->translate('- please choose -')] + $options,
         ]);
     }
 }

--- a/library/Vspheredb/ProvidedHook/Director/ImportSource.php
+++ b/library/Vspheredb/ProvidedHook/Director/ImportSource.php
@@ -130,9 +130,7 @@ class ImportSource extends ImportSourceHook implements TableWithVCenterFilter, T
         ]);
         $form->addElement('select', 'vcenter_uuid', [
             'label' => mt('vspheredb', 'vCenter'),
-            'multiOptions' => [
-                null => mt('vspheredb', '- any -')
-            ] + self::enumVCenters(),
+            'multiOptions' => ['' => mt('vspheredb', '- any -')] + self::enumVCenters(),
         ]);
         $type = $form->getSentOrObjectSetting('object_type');
         if ($type === 'virtual_machine') {

--- a/library/Vspheredb/Web/Form/ChooseDbResourceForm.php
+++ b/library/Vspheredb/Web/Form/ChooseDbResourceForm.php
@@ -85,7 +85,7 @@ class ChooseDbResourceForm extends Form
         $this->addElement('select', 'resource', [
             'required'      => true,
             'label'         => $this->translate('DB Resource'),
-            'multiOptions'  => [null => $this->translate('- please choose -')] + $resources,
+            'multiOptions'  => ['' => $this->translate('- please choose -')] + $resources,
             'class'         => 'autosubmit',
             'value'         => $config->get('db', 'resource')
         ]);

--- a/library/Vspheredb/Web/Form/ChooseInfluxDatabaseForm.php
+++ b/library/Vspheredb/Web/Form/ChooseInfluxDatabaseForm.php
@@ -124,7 +124,7 @@ class ChooseInfluxDatabaseForm extends Form
 
     protected function getDbOptions()
     {
-        return [null => $this->translate('Please choose')]
+        return ['' => $this->translate('Please choose')]
         + \array_combine($this->dbList, $this->dbList)
         + ['_new' => ' -> ' . $this->translate('Create a new Database')];
     }

--- a/library/Vspheredb/Web/Form/Element/VCenterSelection.php
+++ b/library/Vspheredb/Web/Form/Element/VCenterSelection.php
@@ -28,9 +28,7 @@ class VCenterSelection extends SelectElement
         parent::__construct($name, $attributes);
         $enum = $this->enumVCenters();
         $this->addAttributes([
-            'options' => $required ? $enum : [
-                null => $this->translate('All vCenters'),
-            ] + $enum,
+            'options' => $required ? $enum : ['' => $this->translate('All vCenters'),] + $enum,
             'class' => 'autosubmit',
         ]);
     }

--- a/library/Vspheredb/Web/Form/FilterHostParentForm.php
+++ b/library/Vspheredb/Web/Form/FilterHostParentForm.php
@@ -57,7 +57,7 @@ class FilterHostParentForm extends Form
 
         $this->addElement('select', 'type', [
             'options' => [
-                null => $this->translate('- filter by event type -')
+                '' => $this->translate('- filter by event type -')
             ] + array_combine($vMotionEvents, $vMotionEvents)
                 + array_combine($otherKnownEvents, $otherKnownEvents),
             'class' => 'autosubmit',
@@ -69,9 +69,7 @@ class FilterHostParentForm extends Form
             $this->registerElement($element);
         } else {
             $this->addElement('select', 'parent', [
-                'options' => [
-                        null => $this->translate('- filter by parent -')
-                    ] + $parents,
+                'options' => ['' => $this->translate('- filter by parent -')] + $parents,
                 'class' => 'autosubmit',
             ]);
         }

--- a/library/Vspheredb/Web/Form/InfluxDbConnectionForm.php
+++ b/library/Vspheredb/Web/Form/InfluxDbConnectionForm.php
@@ -58,7 +58,7 @@ class InfluxDbConnectionForm extends Form
                 'InfluxDB API version, autodetect should work fine'
             ),
             'options' => [
-                null => $this->translate('Autodetect'),
+                '' => $this->translate('Autodetect'),
                 'v1' => 'v1',
                 'v2' => 'v2',
             ],

--- a/library/Vspheredb/Web/Form/InfluxDbConnectionForm.php
+++ b/library/Vspheredb/Web/Form/InfluxDbConnectionForm.php
@@ -177,7 +177,7 @@ class InfluxDbConnectionForm extends Form
         }
         $element = $this->getElement('api_version');
         assert($element instanceof SelectElement);
-        $autoOption = $element->getOption(null);
+        $autoOption = $element->getOption('');
         $autoOption->setLabel(\sprintf(
             $this->translate('Autodetect: %s API, Version is %s'),
             $apiVersion,

--- a/library/Vspheredb/Web/Form/LogLevelForm.php
+++ b/library/Vspheredb/Web/Form/LogLevelForm.php
@@ -54,7 +54,7 @@ class LogLevelForm extends InlineForm
             NextConfirmCancel::buttonCancel($this->translate('Cancel'))
         );
         $toggle->showWithConfirm(new SelectElement('log_level', [
-            'options'  => [null => $this->translate('- please choose -')] + $this->listLogLevels(),
+            'options'  => ['' => $this->translate('- please choose -')] + $this->listLogLevels(),
             'required' => true,
             'value'    => $currentLevel,
         ]));

--- a/library/Vspheredb/Web/Form/MonitoringConnectionForm.php
+++ b/library/Vspheredb/Web/Form/MonitoringConnectionForm.php
@@ -362,8 +362,6 @@ class MonitoringConnectionForm extends Form
 
     protected function optionalEnum($values): array
     {
-        return [
-            null => $this->translate('- please choose -'),
-        ] + $values;
+        return ['' => $this->translate('- please choose -')] + $values;
     }
 }

--- a/library/Vspheredb/Web/Form/PerfdataConsumerForm.php
+++ b/library/Vspheredb/Web/Form/PerfdataConsumerForm.php
@@ -72,9 +72,7 @@ class PerfdataConsumerForm extends ObjectForm
         }
         $this->addElement('select', 'implementation', [
             'label'    => $this->translate('Implementation'),
-            'options'  => [
-                    null => $this->translate('- please choose -'),
-                ] + PerfDataConsumerHook::enum(),
+            'options'  => ['' => $this->translate('- please choose -')] + PerfDataConsumerHook::enum(),
             'required' => true,
             'class'    => 'autosubmit',
         ]);

--- a/library/Vspheredb/Web/Form/VCenterServerForm.php
+++ b/library/Vspheredb/Web/Form/VCenterServerForm.php
@@ -124,8 +124,8 @@ class VCenterServerForm extends Form
                 . ' choose it\'s protocol right here'
             ),
             'multiOptions' => [
-                null     => $this->translate('- please choose -'),
-                'HTTP'   => $this->translate('HTTP proxy'),
+                '' => $this->translate('- please choose -'),
+                'HTTP' => $this->translate('HTTP proxy'),
                 'SOCKS5' => $this->translate('SOCKS5 proxy'),
             ],
             'class' => 'autosubmit'

--- a/library/Vspheredb/Web/Form/VCenterShipMetricsForm.php
+++ b/library/Vspheredb/Web/Form/VCenterShipMetricsForm.php
@@ -92,7 +92,7 @@ class VCenterShipMetricsForm extends ObjectForm
         }
         $this->addElement('select', 'consumer', [
             'label' => $this->translate('Consumer'),
-            'options' => [null => $this->translate('- please choose -')] + $this->enumConsumers($consumers),
+            'options' => ['' => $this->translate('- please choose -')] + $this->enumConsumers($consumers),
             'description' => Html::sprintf(
                 $this->translate('Choose one of your configured %s'),
                 Link::create($this->translate('Performance Data Consumers'), 'vspheredb/perfdata/consumers')

--- a/module.info
+++ b/module.info
@@ -1,5 +1,5 @@
 Name: vSphereDB
-Version: 1.8.1
+Version: 1.8.2
 Depends: incubator (>=0.23.0)
 Description: Icinga vSphere® Integration
  This module replicates your most important vCenter configuration items. It


### PR DESCRIPTION
Remove cases where `null` was used as an array offset, which is deprecated since PHP 8.5 and replace `null` with `''` in `SelectElement::getOption()` calls, as the placeholder option is keyed by an empty string, not null.

Cherry-picked the commits 80ac118682c4871f9edb96d171bfbda5ac23eaa8 and e949d5830e46d9b569ea51a114396a7a45ad95a9 that are already merged to the `main`.

fixes #619 
