### PR TITLE
Fix/type error null parentuuid in monitoring rules tree

### DIFF
--- a/library/Vspheredb/Monitoring/Rule/Definition/DiskUsageRuleDefinition.php
+++ b/library/Vspheredb/Monitoring/Rule/Definition/DiskUsageRuleDefinition.php
@@ -37,6 +37,9 @@ class DiskUsageRuleDefinition extends MonitoringRuleDefinition
 
     protected function checkDisk($disk, Settings $settings): ?SingleCheckResult
     {
+        if ((int) $disk->capacity === 0) {
+            return null;
+        }
         if ($filter = $settings->get('disk_path_filter')) {
             if (!$this->filterMatchesPath($filter, $disk->disk_path)) {
                 return null;

--- a/library/Vspheredb/Monitoring/Rule/MonitoringRulesTree.php
+++ b/library/Vspheredb/Monitoring/Rule/MonitoringRulesTree.php
@@ -106,8 +106,11 @@ class MonitoringRulesTree
     public function getInheritedSettingsFor(BaseDbObject $object): InheritedSettings
     {
         $uuid = $object->object()->get('parent_uuid');
-        $parents = [$uuid, ...$this->listParentUuidsFor($uuid)];
-
+        if ($uuid === null) {
+            $parents = [MonitoringRuleSet::NO_OBJECT];
+        } else {
+            $parents = [$uuid, ...$this->listParentUuidsFor($uuid)];
+        }
         return InheritedSettings::loadForUuids($parents, $this, $this->db);
     }
 

--- a/library/Vspheredb/Web/Table/VmDiskUsageTable.php
+++ b/library/Vspheredb/Web/Table/VmDiskUsageTable.php
@@ -77,7 +77,9 @@ class VmDiskUsageTable extends ZfQueryBasedTable
         }
 
         $free = Format::bytes($row->free_space)
-            . sprintf(' (%0.3f%%)', ($row->free_space / $row->capacity) * 100);
+            . ($row->capacity > 0
+                ? sprintf(' (%0.3f%%)', ($row->free_space / $row->capacity) * 100)
+                : ' (n/a)');
 
         $tr = $this::tr([
             $this::td($caption, [

--- a/library/Vspheredb/Web/Widget/SimpleUsageBar.php
+++ b/library/Vspheredb/Web/Widget/SimpleUsageBar.php
@@ -33,7 +33,9 @@ class SimpleUsageBar extends BaseHtmlElement
 
     protected function assemble()
     {
-        $usedPercent = $this->used / $this->total;
+        $usedPercent = ($this->total > 0)
+            ? $this->used / $this->total
+            : 0;
 
         $bar = Html::tag('span', [
             'href' => '#',


### PR DESCRIPTION
customer suggestion of the following fix ref/nc/895761

MonitoringRulesTree::getInheritedSettingsFor() returns zero to MonitoringRuleSet::loadOptionalForUuid(string $uuid), when an object has no parent_uuid. With PHP 8.x the leads to an TypeError and also blocks Rule-Refreshing.