### PR TITLE
Add clickable filter for some objects

### DIFF
--- a/application/controllers/VmsController.php
+++ b/application/controllers/VmsController.php
@@ -93,6 +93,8 @@ class VmsController extends ObjectsController
     {
         $this->handleTabs();
         $urlParams = $this->getParentParamsToPreserve();
+        $filterVdi = $this->params->get('filter_vdi', '0');
+
         $this->actions()->add([
             Link::create(
                 $this->translate('Disk Usage'),
@@ -106,10 +108,19 @@ class VmsController extends ObjectsController
                 $urlParams,
                 ['class' => 'icon-left-small']
             ),
+            Link::create(
+                $filterVdi === '1' ? $this->translate('Show All VMs') : $this->translate('Hide VDI, Templates & Off'),
+                'vspheredb/vms/snapshot',
+                array_merge($urlParams, ['filter_vdi' => $filterVdi === '1' ? '0' : '1']),
+                ['class' => 'icon-filter']
+            )
         ]);
+
         $table = new VmsSnapshotsTable($this->db(), $this->url());
+
         (new AdditionalTableActions($table, Auth::getInstance(), $this->url()))
             ->appendTo($this->actions());
         $this->showTable($table, 'vspheredb/vms', $this->translate('Virtual Machines with Snapshots'));
     }
 }
+

--- a/application/controllers/VmsController.php
+++ b/application/controllers/VmsController.php
@@ -123,4 +123,3 @@ class VmsController extends ObjectsController
         $this->showTable($table, 'vspheredb/vms', $this->translate('Virtual Machines with Snapshots'));
     }
 }
-

--- a/library/Vspheredb/Web/Table/Objects/VmsSnapshotsTable.php
+++ b/library/Vspheredb/Web/Table/Objects/VmsSnapshotsTable.php
@@ -9,11 +9,19 @@ use Icinga\Module\Vspheredb\Util;
 class VmsSnapshotsTable extends ObjectsTable
 {
     protected $baseUrl = 'vspheredb/vm';
+    
+    protected $vmsRequestUrl;
 
     protected $searchColumns = [
         'object_name',
         'guest_host_name',
     ];
+
+    public function __construct($db, $url = null)
+    {
+        $this->vmsRequestUrl = $url;
+        parent::__construct($db, $url);
+    }
 
     public function filterHost($uuid)
     {
@@ -69,6 +77,21 @@ class VmsSnapshotsTable extends ObjectsTable
             'vms.vm_uuid = vm.uuid',
             []
         )->group('vm.uuid');
+
+        $urlFilter = '0';
+        if ($this->vmsRequestUrl !== null) {
+            $urlFilter = $this->vmsRequestUrl->getParam('filter_vdi', '0');
+        }
+
+        if ($urlFilter === '1') {
+            $query->where("vm.template = 'n' OR vm.template = 0");
+            $query->where("vm.runtime_power_state != 'poweredOff'");
+            $query->where("LOWER(o.object_name) NOT LIKE 'cp-template-%'");
+            $query->where("LOWER(o.object_name) NOT LIKE 'cp-replica-%'");
+            $query->where("LOWER(o.object_name) NOT LIKE '%-vdi-%'");
+            $query->where("LOWER(o.object_name) NOT LIKE '%-gis-%'");
+            $query->where("LOWER(o.object_name) NOT LIKE '%horizon%'");
+        }
 
         return $query;
     }


### PR DESCRIPTION
This is a feature suggestion for filtering out junk or nuisance objects when using the snapshots report to find lingering snapshots
We also run VDI, which means there are lots of snapshots that are expected and that we really don't want cluttering up the report.
I am not a huge fan of the approach in this PR is since it embeds some of our naming patterns and business logic in code, but I thought I'd open it anyways to begin a conversation in case this feature is thought to be generally useful (in which case I wouldn't need to maintain internal patches long-term.)