### PR TITLE
Fix zero-capacity disk rendering and root rule inheritance

### DIFF
--- a/library/Vspheredb/Monitoring/Rule/MonitoringRulesTree.php
+++ b/library/Vspheredb/Monitoring/Rule/MonitoringRulesTree.php
@@ -109,9 +109,27 @@ class MonitoringRulesTree
     public function getInheritedSettingsFor(BaseDbObject $object): InheritedSettings
     {
         $uuid = $object->object()->get('parent_uuid');
-        $parents = [$uuid, ...$this->listParentUuidsFor($uuid)];
 
-        return InheritedSettings::loadForUuids($parents, $this, $this->db);
+        return InheritedSettings::loadForUuids(
+            $this->listInheritedParentUuidsFor($uuid),
+            $this,
+            $this->db
+        );
+    }
+
+    /**
+     * @param string|int|null $uuid
+     * @return string[]
+     */
+    protected function listInheritedParentUuidsFor(string|int|null $uuid): array
+    {
+        if ($uuid === null || $uuid === 0) {
+            return [MonitoringRuleSet::NO_OBJECT];
+        }
+
+        $uuid = (string) $uuid;
+
+        return [$uuid, ...$this->listParentUuidsFor($uuid)];
     }
 
     /**

--- a/library/Vspheredb/Web/Table/VmDiskUsageTable.php
+++ b/library/Vspheredb/Web/Table/VmDiskUsageTable.php
@@ -79,15 +79,15 @@ class VmDiskUsageTable extends ZfQueryBasedTable
             $this->root = $row;
         }
 
-        $free = Format::bytes($row->free_space)
-            . sprintf(' (%0.3f%%)', ($row->free_space / $row->capacity) * 100);
-
         $tr = $this::tr([
             $this::td($caption, [
                 'title' => $caption
             ]),
             $this::td(Format::bytes($row->capacity), ['class' => 'vm-disk-usage-capacity']),
-            $this::td($free, ['class' => 'vm-disk-usage-free']),
+            $this::td(
+                $this->renderFreeSpace($row->free_space, $row->capacity),
+                ['class' => 'vm-disk-usage-free']
+            ),
             $this::td($this->makeDisk($row), ['class' => 'vm-disk-usage-usage'])
         ]);
 
@@ -133,11 +133,13 @@ class VmDiskUsageTable extends ZfQueryBasedTable
             return;
         }
 
-        $free = Format::bytes($this->totalFree) . sprintf(' (%0.3f%%)', ($this->totalFree / $this->totalSize) * 100);
         $this->getFooter()->add($this::tr([
             $this::th(Html::tag('strong', null, $this->translate('Total'))),
             $this::th(Format::bytes($this->totalSize), ['class' => 'vm-disk-usage-capacity']),
-            $this::th($free, ['class' => 'vm-disk-usage-free']),
+            $this::th(
+                $this->renderFreeSpace($this->totalFree, $this->totalSize),
+                ['class' => 'vm-disk-usage-free']
+            ),
             $this::th($this->makeDisk((object) [
                 'disk_path' => $this->translate('Total'),
                 'capacity'  => $this->totalSize,
@@ -156,6 +158,21 @@ class VmDiskUsageTable extends ZfQueryBasedTable
         $used = $disk->capacity - $disk->free_space;
 
         return new SimpleUsageBar($used, $disk->capacity, $disk->disk_path);
+    }
+
+    /**
+     * @param int|float $freeSpace
+     * @param int|float $capacity
+     * @return string Formatted free space with percentage, or "(n/a)" when capacity is zero
+     */
+    protected function renderFreeSpace(int|float $freeSpace, int|float $capacity): string
+    {
+        $free = Format::bytes($freeSpace);
+        if ($capacity > 0) {
+            return $free . sprintf(' (%0.3f%%)', ($freeSpace / $capacity) * 100);
+        }
+
+        return $free . ' (n/a)';
     }
 
     public function prepareQuery()

--- a/library/Vspheredb/Web/Widget/SimpleUsageBar.php
+++ b/library/Vspheredb/Web/Widget/SimpleUsageBar.php
@@ -36,7 +36,7 @@ class SimpleUsageBar extends BaseHtmlElement
 
     protected function assemble()
     {
-        $usedPercent = $this->used / $this->total;
+        $usedPercent = $this->getUsedPercent();
 
         $bar = Html::tag('span', [
             'href' => '#',
@@ -49,5 +49,17 @@ class SimpleUsageBar extends BaseHtmlElement
             ->addFor($bar, ['width' => sprintf('%0.3F%%', $usedPercent * 100)]);
 
         $this->add([$bar, $style]);
+    }
+
+    /**
+     * @return float Used fraction in [0, 1]; returns 0.0 when total is zero
+     */
+    protected function getUsedPercent(): float
+    {
+        if ($this->total > 0) {
+            return $this->used / $this->total;
+        }
+
+        return 0.0;
     }
 }


### PR DESCRIPTION
This extracts fixes from PRs #630, #631, and #632 into a clean branch without carrying over the mixed/stacked/incomplete changes.

- Avoid division by zero when rendering guest disk rows with `capacity = 0`.
- Also fix the same division-by-zero issue in the guest disk table footer.
- Avoid division by zero in `SimpleUsageBar` when the total is zero.
- Fix monitoring rule inheritance for objects without a parent UUID.

closes #630 
closes #631 
closes #632