### PR TITLE
Require Icinga PHP Library and Thirdparty

### DIFF
--- a/doc/01-Installation.md
+++ b/doc/01-Installation.md
@@ -6,6 +6,8 @@ Requirements
 
 * Icinga Web 2 (&gt;= 2.10)
 * PHP (&gt;= 7.4 or 8.x - 64bit only)
+* [Icinga PHP Library (ipl)](https://github.com/Icinga/icinga-php-library) ≥ 0.19.2
+* [Icinga PHP Thirdparty](https://github.com/Icinga/icinga-php-thirdparty) ≥ 0.15.3
 * php-soap
 * php-pcntl (might already be built into your PHP binary)
 * php-posix (on RHEL/CentOS this is php-process, or rh-php7x-php-process)

--- a/module.info
+++ b/module.info
@@ -1,6 +1,8 @@
 Name: vSphereDB
 Version: main
 Depends: incubator (>=0.23.0)
+Requires:
+  Libraries: icinga-php-library (>=0.19.2), icinga-php-thirdparty (>=0.15.3)
 Description: Icinga vSphere® Integration
  This module replicates your most important vCenter configuration items. It
  provides a fast, lightweight (read-only) frontend and highlights potential


### PR DESCRIPTION
The module already uses these libraries, but neither the module metadata nor the installation docs required them explicitly. Declaring them makes the runtime dependencies visible before module activation.