### PR TITLE
Add daemon Promise cleanup compatibility helper

### DIFF
--- a/library/Vspheredb/CheckPluginHelper.php
+++ b/library/Vspheredb/CheckPluginHelper.php
@@ -8,6 +8,7 @@ namespace Icinga\Module\Vspheredb;
 use Exception;
 use gipfl\Cli\Screen;
 use Icinga\Module\Vspheredb\Clicommands\Command;
+use Icinga\Module\Vspheredb\Daemon\PromiseUtil;
 use Icinga\Module\Vspheredb\Data\Anonymizer;
 use InvalidArgumentException;
 use React\Promise\PromiseInterface;
@@ -75,14 +76,17 @@ trait CheckPluginHelper
             }
 
             if ($result instanceof PromiseInterface) {
-                $result->then(function () {
-                    // All done
-                }, function (Exception $e) {
-                    $this->addProblem('UNKNOWN', $e->getMessage());
-                    $this->showOptionalTrace($e);
-                })->finally(function () {
-                    $this->shutdown();
-                });
+                PromiseUtil::finally(
+                    $result->then(function () {
+                        // All done
+                    }, function (Exception $e) {
+                        $this->addProblem('UNKNOWN', $e->getMessage());
+                        $this->showOptionalTrace($e);
+                    }),
+                    function () {
+                        $this->shutdown();
+                    }
+                );
             } else {
                 $this->shutdown();
             }

--- a/library/Vspheredb/Daemon/PromiseUtil.php
+++ b/library/Vspheredb/Daemon/PromiseUtil.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Icinga\Module\Vspheredb\Daemon;
+
+use React\Promise\PromiseInterface;
+
+/**
+ * ReactPHP Promise compatibility helpers
+ */
+class PromiseUtil
+{
+    /**
+     * Register cleanup on ReactPHP Promise v2 and v3 promises
+     *
+     * @param PromiseInterface $promise  Promise to register cleanup on
+     * @param callable         $callback Callback receiving no arguments
+     *
+     * @return PromiseInterface
+     */
+    public static function finally(PromiseInterface $promise, callable $callback): PromiseInterface
+    {
+        if (method_exists($promise, 'finally')) {
+            return $promise->finally($callback);
+        }
+
+        return $promise->always($callback);
+    }
+}

--- a/library/Vspheredb/Monitoring/CheckPlugin.php
+++ b/library/Vspheredb/Monitoring/CheckPlugin.php
@@ -5,6 +5,8 @@
 
 namespace Icinga\Module\Vspheredb\Monitoring;
 
+use Icinga\Module\Vspheredb\Daemon\PromiseUtil;
+
 class CheckPlugin
 {
     /** @var array */
@@ -34,15 +36,18 @@ class CheckPlugin
             }
 
             if ($result instanceof PromiseInterface) {
-                $result->then(function () {
-                    echo "as\n";
-                }, function (Exception $e) {
-                    var_dump('whut');
-                    $this->addProblem('UNKNOWN', $e->getMessage());
-                })->finally(function () {
-                    var_dump('Shut after res');
-                    $this->shutdown();
-                });
+                PromiseUtil::finally(
+                    $result->then(function () {
+                        echo "as\n";
+                    }, function (Exception $e) {
+                        var_dump('whut');
+                        $this->addProblem('UNKNOWN', $e->getMessage());
+                    }),
+                    function () {
+                        var_dump('Shut after res');
+                        $this->shutdown();
+                    }
+                );
             } else {
                 $this->shutdown();
             }


### PR DESCRIPTION
ReactPHP Promise v2 exposes cleanup through always(), while v3 exposes it through finally(). Use a small daemon helper so check-plugin shutdown registration works with both dependency branches.