### PR TITLE
Close sync RPC connection after controller calls

### DIFF
--- a/application/controllers/AsyncControllerHelper.php
+++ b/application/controllers/AsyncControllerHelper.php
@@ -17,9 +17,25 @@ trait AsyncControllerHelper
     /** @var RemoteClient */
     protected $remoteClient;
 
+    /**
+     * Call the daemon synchronously and close the RPC connection afterwards
+     *
+     * The socket is closed in finally so ReactPHP does not keep an active
+     * stream watcher after the awaited request has completed.
+     *
+     * @param string $method
+     * @param mixed[] $params
+     * @param int $timeout
+     *
+     * @return mixed
+     */
     protected function syncRpcCall($method, $params = [], $timeout = 30)
     {
-        return await(timeout($this->remoteClient()->request($method, $params), $timeout));
+        try {
+            return await(timeout($this->remoteClient()->request($method, $params), $timeout));
+        } finally {
+            $this->remoteClient()->close();
+        }
     }
 
     /**

--- a/library/Vspheredb/Daemon/RemoteClient.php
+++ b/library/Vspheredb/Daemon/RemoteClient.php
@@ -31,11 +31,29 @@ class RemoteClient
         $this->loop = $loop;
     }
 
+    /**
+     * @param string $method
+     * @param mixed $params
+     *
+     * @return \React\Promise\PromiseInterface<mixed>
+     */
     public function request($method, $params = null)
     {
         return $this->connection()->then(function (JsonRpcConnection $connection) use ($method, $params) {
             return $connection->request($method, $params);
         });
+    }
+
+    /**
+     * Close the JSON-RPC connection and deregister its event loop watchers
+     *
+     * @return void
+     */
+    public function close(): void
+    {
+        if ($this->connection !== null) {
+            $this->connection->close();
+        }
     }
 
     public function notify($method, $params = null)


### PR DESCRIPTION
Synchronous controller RPC calls waited for the daemon response but left the underlying JSON-RPC socket open. ReactPHP kept the stream watcher registered, so the shutdown scheduler could block in stream_select() after the request had finished.

Close the daemon client in a finally block and document the RPC call contract.